### PR TITLE
Update to dm-paperclip to work with rails 3.0.3

### DIFF
--- a/lib/dm-paperclip/attachment.rb
+++ b/lib/dm-paperclip/attachment.rb
@@ -3,6 +3,7 @@ module Paperclip
   # when the model saves, deletes when the model is destroyed, and processes
   # the file upon assignment.
   class Attachment
+  include IOStream
 
     def self.default_options
       @default_options ||= {
@@ -78,14 +79,13 @@ module Paperclip
 
       if uploaded_file.respond_to?(:[])
         uploaded_file = uploaded_file.to_mash
-        
-        @queued_for_write[:original]   = uploaded_file['tempfile']
+        @queued_for_write[:original]   = uploaded_file.to_tempfile
         instance_write(:file_name,       uploaded_file['filename'].strip.gsub(/[^\w\d\.\-]+/, '_'))
         instance_write(:content_type,    uploaded_file['content_type'] ? uploaded_file['content_type'].strip : uploaded_file['tempfile'].content_type.to_s.strip)
         instance_write(:file_size,       uploaded_file['size'] ? uploaded_file['size'].to_i : uploaded_file['tempfile'].size.to_i)
         instance_write(:updated_at,      Time.now)
       else
-        @queued_for_write[:original]   = uploaded_file.to_tempfile
+        @queued_for_write[:original]   = to_tempfile(uploaded_file)
         instance_write(:file_name,       uploaded_file.original_filename.strip.gsub(/[^\w\d\.\-]+/, '_'))
         instance_write(:content_type,    uploaded_file.content_type.to_s.strip)
         instance_write(:file_size,       uploaded_file.size.to_i)

--- a/lib/dm-paperclip/iostream.rb
+++ b/lib/dm-paperclip/iostream.rb
@@ -3,11 +3,12 @@
 module IOStream
 
   # Returns a Tempfile containing the contents of the readable object.
-  def to_tempfile
-    name = respond_to?(:original_filename) ? original_filename : (respond_to?(:path) ? path : "stream")
+ def to_tempfile(object)
+   return object.to_tempfile if object.respond_to?(:to_tempfile)
+   name = object.respond_to?(:original_filename) ? object.original_filename : (object.respond_to?(:path) ? object.path : "stream")
     tempfile = Paperclip::Tempfile.new(File.basename(name))
     tempfile.binmode
-    self.stream_to(tempfile)
+   stream_to(object, tempfile)
   end
 
   # Copies one read-able object from one place to another in blocks, obviating the need to load
@@ -15,15 +16,15 @@ module IOStream
   # StringIO and Tempfile, then either can have its data copied anywhere else without typing
   # worries or memory overhead worries. Returns a File if a String is passed in as the destination
   # and returns the IO or Tempfile as passed in if one is sent as the destination.
-  def stream_to path_or_file, in_blocks_of = 8192
+ def stream_to object, path_or_file, in_blocks_of = 8192
     dstio = case path_or_file
             when String   then File.new(path_or_file, "wb+")
             when IO       then path_or_file
             when Tempfile then path_or_file
             end
     buffer = ""
-    self.rewind
-    while self.read(in_blocks_of, buffer) do
+   object.rewind
+   while object.read(in_blocks_of, buffer) do
       dstio.write(buffer)
     end
     dstio.rewind    
@@ -31,17 +32,6 @@ module IOStream
   end
 end
 
-class IO #:nodoc:
-  include IOStream
-end
-
-%w( Tempfile StringIO ).each do |klass|
-  if Object.const_defined? klass
-    Object.const_get(klass).class_eval do
-      include IOStream
-    end
-  end
-end
 
 # Corrects a bug in Windows when asking for Tempfile size.
 if defined? Tempfile


### PR DESCRIPTION
I applied changes made to paperclip (not dm) to your repository to make it work with rails 3.0.3. This is based on 

https://github.com/thoughtbot/paperclip/commit/ef7233d25700a7e69cebd2334b656fa9ca0ae927#lib/paperclip/iostream.rb
