### PR TITLE
defined? to Object.const_defined?

### DIFF
--- a/lib/dm-paperclip/storage.rb
+++ b/lib/dm-paperclip/storage.rb
@@ -174,13 +174,13 @@ module Paperclip
 
       def parse_credentials creds
         creds = find_credentials(creds).to_mash.stringify_keys!
-        if defined? Merb && Merb.respond_to?(:env)
+        if Object.const_defined?('Merb') && Merb.respond_to?(:env)
           (creds[Merb.env] || creds).symbolize_keys
-        elsif defined? RAILS_ENV
+        elsif Object.const_defined?('RAILS_ENV')
           (creds[RAILS_ENV] || creds).symbolize_keys
-        elsif defined? Rails && Rails.respond_to(:env)
+        elsif Object.const_defined?('Rails') && Rails.respond_to(:env)
           (creds[Rails.env] || creds).symbolize_keys
-        elsif defined? RACK_ENV
+        elsif Object.const_defined?('RACK_ENV')
           (creds[RACK_ENV] || creds).symbolize_keys
         else
           creds.symbolize_keys


### PR DESCRIPTION
My sinatra project utilizing dm-paperclip was encountering the following NameError:

uninitialized constant Paperclip::Storage::S3::Merb

/app/vendor/bundle/ruby/1.9.1/gems/aws-s3-0.6.2/lib/aws/s3/extensions.rb in const_missing_from_s3_library
      const_missing_not_from_s3_library(sym)
/app/vendor/bundle/ruby/1.9.1/gems/dm-paperclip-2.4.1/lib/dm-paperclip/storage.rb in parse_credentials
          (creds[Merb.env] || creds).symbolize_keys
/app/vendor/bundle/ruby/1.9.1/gems/dm-paperclip-2.4.1/lib/dm-paperclip/storage.rb in block in extended
          @s3_credentials = parse_credentials(@options[:s3_credentials])

Using Object.constant_defined? appears to have fixed my problem.
