### PR TITLE
update dm-paperclip for ruby 1.9.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+source :rubygems
+gem 'datamapper'
+gem 'extlib'
+
+group :test do
+  gem 'aws-s3'
+  gem "dm-sqlite-adapter"
+  gem 'shoulda'
+  gem 'mocha'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,75 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    addressable (2.2.6)
+    aws-s3 (0.6.2)
+      builder
+      mime-types
+      xml-simple
+    bcrypt-ruby (2.1.4)
+    builder (3.0.0)
+    data_objects (0.10.6)
+      addressable (~> 2.1)
+    datamapper (1.1.0)
+      dm-aggregates (= 1.1.0)
+      dm-constraints (= 1.1.0)
+      dm-core (= 1.1.0)
+      dm-migrations (= 1.1.0)
+      dm-serializer (= 1.1.0)
+      dm-timestamps (= 1.1.0)
+      dm-transactions (= 1.1.0)
+      dm-types (= 1.1.0)
+      dm-validations (= 1.1.0)
+    dm-aggregates (1.1.0)
+      dm-core (~> 1.1.0)
+    dm-constraints (1.1.0)
+      dm-core (~> 1.1.0)
+    dm-core (1.1.0)
+      addressable (~> 2.2.4)
+    dm-do-adapter (1.1.0)
+      data_objects (~> 0.10.2)
+      dm-core (~> 1.1.0)
+    dm-migrations (1.1.0)
+      dm-core (~> 1.1.0)
+    dm-serializer (1.1.0)
+      dm-core (~> 1.1.0)
+      fastercsv (~> 1.5.4)
+      json (~> 1.4.6)
+    dm-sqlite-adapter (1.1.0)
+      dm-do-adapter (~> 1.1.0)
+      do_sqlite3 (~> 0.10.2)
+    dm-timestamps (1.1.0)
+      dm-core (~> 1.1.0)
+    dm-transactions (1.1.0)
+      dm-core (~> 1.1.0)
+    dm-types (1.1.0)
+      bcrypt-ruby (~> 2.1.4)
+      dm-core (~> 1.1.0)
+      fastercsv (~> 1.5.4)
+      json (~> 1.4.6)
+      stringex (~> 1.2.0)
+      uuidtools (~> 2.1.2)
+    dm-validations (1.1.0)
+      dm-core (~> 1.1.0)
+    do_sqlite3 (0.10.6)
+      data_objects (= 0.10.6)
+    extlib (0.9.15)
+    fastercsv (1.5.4)
+    json (1.4.6)
+    mime-types (1.16)
+    mocha (0.9.12)
+    shoulda (2.11.3)
+    stringex (1.2.1)
+    uuidtools (2.1.2)
+    xml-simple (1.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  aws-s3
+  datamapper
+  dm-sqlite-adapter
+  extlib
+  mocha
+  shoulda

--- a/dm-paperclip.gemspec
+++ b/dm-paperclip.gemspec
@@ -2,15 +2,15 @@
 
 Gem::Specification.new do |s|
   s.name = %q{dm-paperclip}
-  s.version = "2.4.1"
+  s.version = "2.4.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["Ken Robertson"]
-  s.date = %q{2010-04-21}
+  s.authors = ["Ken Robertson", "Mr Rogers"]
+  s.date = %q{2011-06-28}kk
   s.email = %q{ken@invalidlogic.com}
   s.extra_rdoc_files = ["README.rdoc"]
   s.files = ["README.rdoc", "LICENSE", "Rakefile", "init.rb", "lib/dm-paperclip", "lib/dm-paperclip/attachment.rb", "lib/dm-paperclip/callback_compatability.rb", "lib/dm-paperclip/geometry.rb", "lib/dm-paperclip/interpolations.rb", "lib/dm-paperclip/iostream.rb", "lib/dm-paperclip/processor.rb", "lib/dm-paperclip/storage.rb", "lib/dm-paperclip/thumbnail.rb", "lib/dm-paperclip/upfile.rb", "lib/dm-paperclip/validations.rb", "lib/dm-paperclip.rb", "tasks/paperclip_tasks.rake", "test/attachment_test.rb", "test/fixtures", "test/fixtures/12k.png", "test/fixtures/50x50.png", "test/fixtures/5k.png", "test/fixtures/bad.png", "test/fixtures/text.txt", "test/geometry_test.rb", "test/helper.rb", "test/integration_test.rb", "test/iostream_test.rb", "test/paperclip_test.rb", "test/storage_test.rb", "test/thumbnail_test.rb"]
-  s.homepage = %q{http://github.com/krobertson/dm-paperclip}
+  s.homepage = %q{http://github.com/bunnymatic/dm-paperclip}
   s.rdoc_options = ["--line-numbers", "--inline-source"]
   s.require_paths = ["lib"]
   s.requirements = ["ImageMagick"]

--- a/dm-paperclip.gemspec
+++ b/dm-paperclip.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Ken Robertson", "Mr Rogers"]
-  s.date = %q{2011-06-28}kk
+  s.date = %q{2011-06-28}
   s.email = %q{ken@invalidlogic.com}
   s.extra_rdoc_files = ["README.rdoc"]
   s.files = ["README.rdoc", "LICENSE", "Rakefile", "init.rb", "lib/dm-paperclip", "lib/dm-paperclip/attachment.rb", "lib/dm-paperclip/callback_compatability.rb", "lib/dm-paperclip/geometry.rb", "lib/dm-paperclip/interpolations.rb", "lib/dm-paperclip/iostream.rb", "lib/dm-paperclip/processor.rb", "lib/dm-paperclip/storage.rb", "lib/dm-paperclip/thumbnail.rb", "lib/dm-paperclip/upfile.rb", "lib/dm-paperclip/validations.rb", "lib/dm-paperclip.rb", "tasks/paperclip_tasks.rake", "test/attachment_test.rb", "test/fixtures", "test/fixtures/12k.png", "test/fixtures/50x50.png", "test/fixtures/5k.png", "test/fixtures/bad.png", "test/fixtures/text.txt", "test/geometry_test.rb", "test/helper.rb", "test/integration_test.rb", "test/iostream_test.rb", "test/paperclip_test.rb", "test/storage_test.rb", "test/thumbnail_test.rb"]

--- a/lib/dm-paperclip/processor.rb
+++ b/lib/dm-paperclip/processor.rb
@@ -43,7 +43,7 @@ module Paperclip
     # Replaces Tempfile's +make_tmpname+ with one that honors file extensions.
     def make_tmpname(basename, n)
       extension = File.extname(basename)
-      sprintf("%s,%d,%d%s", File.basename(basename, extension), $$, n, extension)
+      sprintf("%s,%d,%d%s", File.basename(basename, extension), $$, n.to_i, extension)
     end
   end
 end

--- a/test/attachment_test.rb
+++ b/test/attachment_test.rb
@@ -1,5 +1,4 @@
-require 'test/helper'
-
+require File.expand_path(File.join(File.dirname(__FILE__), 'helper'))
 class Dummy
   # This is a dummy class
 end

--- a/test/geometry_test.rb
+++ b/test/geometry_test.rb
@@ -2,7 +2,7 @@ require 'rubygems'
 require 'test/unit'
 require 'shoulda'
 
-require File.join(File.dirname(__FILE__), '..', 'lib', 'dm-paperclip', 'geometry.rb')
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib', 'dm-paperclip', 'geometry.rb'))
 
 class GeometryTest < Test::Unit::TestCase
   context "Paperclip::Geometry" do

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -1,4 +1,4 @@
-require 'test/helper.rb'
+require File.expand_path(File.join(File.dirname(__FILE__), 'helper'))
 
 class IntegrationTest < Test::Unit::TestCase
   context "Many models at once" do

--- a/test/iostream_test.rb
+++ b/test/iostream_test.rb
@@ -1,4 +1,4 @@
-require 'test/helper'
+require File.expand_path(File.join(File.dirname(__FILE__), 'helper'))
 
 class IOStreamTest < Test::Unit::TestCase
   context "IOStream" do

--- a/test/paperclip_test.rb
+++ b/test/paperclip_test.rb
@@ -1,4 +1,4 @@
-require 'test/helper.rb'
+require File.expand_path(File.join(File.dirname(__FILE__), 'helper'))
 
 class PaperclipTest < Test::Unit::TestCase
   context "A DataMapper model with an 'avatar' attachment" do

--- a/test/storage_test.rb
+++ b/test/storage_test.rb
@@ -1,4 +1,4 @@
-require 'test/helper'
+require File.expand_path(File.join(File.dirname(__FILE__), 'helper'))
 require 'aws/s3'
 
 class StorageTest < Test::Unit::TestCase

--- a/test/thumbnail_test.rb
+++ b/test/thumbnail_test.rb
@@ -4,8 +4,8 @@ require 'shoulda'
 require 'mocha'
 require 'tempfile'
 
-require File.join(File.dirname(__FILE__), '..', 'lib', 'dm-paperclip', 'geometry.rb')
-require File.join(File.dirname(__FILE__), '..', 'lib', 'dm-paperclip', 'thumbnail.rb')
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib', 'dm-paperclip', 'geometry.rb'))
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib', 'dm-paperclip', 'thumbnail.rb'))
 
 class ThumbnailTest < Test::Unit::TestCase
 


### PR DESCRIPTION
hey there

just made a quick update to the dm-paperclip to support new sprintf in ruby 1.9.2 which seems to fail with nil conversions.

<pre><code>
ruby-1.8.7> sprintf('%d',nil)
=> "0"

ruby-1.9.2> sprintf('%d',nil)
TypeError: can't convert nil into Integer
        from (irb):1:in `sprintf'n = nil
</code></pre>


I looked at all the different forks and it seems like bundler is picking up your original branch.  I tried a couple other forks (gix and solnic) that had more code dev but they had the same issue, so i thought i'd start at the base.  

The fix is simple.  The other mods i've done are just to generalize the tests so they worked on my system (make "require" statements use File.expand_path) and adding a Gemfile so i could build a bundle from which to run the tests.  
