### PR TITLE
Make Paperclip.config.root option to be effective

### DIFF
--- a/lib/dm-paperclip/attachment.rb
+++ b/lib/dm-paperclip/attachment.rb
@@ -8,7 +8,7 @@ module Paperclip
     def self.default_options
       @default_options ||= {
         :url                   => "/system/:attachment/:id/:style/:filename",
-        :path                  => ":rails_root/public:url",
+        :path                  => ":web_root/public:url",
         :styles                => {},
         :processors            => [:thumbnail],
         :convert_options       => {},

--- a/lib/dm-paperclip/interpolations.rb
+++ b/lib/dm-paperclip/interpolations.rb
@@ -59,13 +59,10 @@ module Paperclip
     end
 
     def web_root attachment, style
-      if Object.const_defined?('Merb')
-        merb_root(attachment, style)
-      elsif Object.const_defined("Rails")
-        rails_root(attachment, style)
-      else
+      Paperclip.config.root ||
+        merb_root(attachment, style) ||
+        rails_root(attachment, style) ||
         ""
-      end
     end
 
     # Returns the Rails.root constant.


### PR DESCRIPTION
As @mkastner mentioned in #8, dm-paperclip uses `/public` on the system root as base path for saving attachment files by default.

Cause for this was `:path` key in `Paperclip::Attachment#default_options` uses `:rails_root`. If you use this gem without Rails, the interpolation always results in `/public`.

I modified the interpolation to refer `:web_root` instead of `:rails_root` and `Paperclip::Interpolation#web_root` refers `Paperclip.config.root` to allow users to customize base path for attachment files.
